### PR TITLE
Add clone step of install to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ you need to explicitly tell git that some media files has changed:
 
 ## Installing
 
+    $ git clone git@github.com:alebedev/git-media.git
+    $ cd git-media
     $ sudo gem install bundler
     $ bundle install
     $ gem build git-media.gemspec


### PR DESCRIPTION
The original README didn't include the git clone step and that was confusing to me, and I imagine might be confusing to other newcomers as well.
