### PR TITLE
smudge: write to stdout in binmode

### DIFF
--- a/lib/git-media/filter-smudge.rb
+++ b/lib/git-media/filter-smudge.rb
@@ -2,6 +2,11 @@ module GitMedia
   module FilterSmudge
 
     def self.print_stream(stream)
+      # create a binary stream to write to stdout
+      # this avoids messing up line endings on windows
+      outstream = IO.try_convert(STDOUT)
+      outstream.binmode
+
       while data = stream.read(4096) do
         print data
       end


### PR DESCRIPTION
Avoids screwing up line endings on windows to resolve #11 .
It is possible that I was only running into this because my environment is set up poorly on Windows. However,  no amount of messing with `core.autocrlf` or `.gitattributes` sems to resolve my issue. This tweak to `filter-smudge` does seem to resolve the issue.