### PR TITLE
Fix the Windows help in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,8 @@ It is important to switch off git smart newline character support for media file
 Use `-crlf` switch in `.gitattributes` (for example `*.mov filter=media -crlf`) or config option `core.autocrlf = false`.
 
 If installing on windows, you might run into a problem verifying certificates
-for S3 or something. If that happens, see the following Gist:
-
-    https://gist.github.com/luislavena/f064211759ee0f806c88
+for S3 or something. If that happens, see the [instructions in this Gist for how
+to update your RubyGems to the proper certificates](https://gist.github.com/luislavena/f064211759ee0f806c88).
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -113,13 +113,9 @@ It is important to switch off git smart newline character support for media file
 Use `-crlf` switch in `.gitattributes` (for example `*.mov filter=media -crlf`) or config option `core.autocrlf = false`.
 
 If installing on windows, you might run into a problem verifying certificates
-for S3 or something. If that happens, modify
+for S3 or something. If that happens, see the following Gist:
 
-	C:\Ruby191\lib\ruby\gems\1.9.1\gems\right_http_connection-1.2.4\lib\right_http_connection.rb
-
-And add at line 310, right before `@http.start`:
-
-      @http.verify_mode     = OpenSSL::SSL::VERIFY_NONE
+    https://gist.github.com/luislavena/f064211759ee0f806c88
 
 ## Copyright
 


### PR DESCRIPTION
The current README suggests that a user having problems with S3 certificates completely disable their certificate checking globally for RubyGems. This opens up a security hole and would actually get them fired from some companies if they followed those instructions (including one I just worked for). I actually considered not using git-media as a result of this advice, but luckily I did some more searching and found a better solution.

There are instructions in a Gist that explain how to fix the problem; I've added them to the README in this pull request.