### PR TITLE
Fix file checkout on Windows (needs binmode).

### DIFF
--- a/lib/git-media/filter-clean.rb
+++ b/lib/git-media/filter-clean.rb
@@ -7,6 +7,7 @@ module GitMedia
 
     def self.run!(input=STDIN, output=STDOUT, info_output=true)
       
+      input.binmode
       # Read first 42 bytes
       # If the file is only 41 bytes long (as in the case of a stub)
       # it will only return a string with a length of 41

--- a/lib/git-media/filter-smudge.rb
+++ b/lib/git-media/filter-smudge.rb
@@ -11,6 +11,8 @@ module GitMedia
       media_buffer = GitMedia.get_media_buffer
       
       # read checksum size
+      STDIN.binmode
+      STDOUT.binmode
       orig = STDIN.readline(64)
       sha = orig.strip # read no more than 64 bytes
       if STDIN.eof? && sha.length == 40 && sha.match(/^[0-9a-fA-F]+$/) != nil


### PR DESCRIPTION
Without binmode files are checked out corrupted.