### PR TITLE
file exists check for scp

### DIFF
--- a/lib/git-media/transport/scp.rb
+++ b/lib/git-media/transport/scp.rb
@@ -24,7 +24,7 @@ module GitMedia
       end
 
       def exist?(file)
-        if `ssh #{@user}@#{@host} #{@sshport} [ -f "#{file}" ] && echo 1 || echo 0`.chomp == "1"
+        if `ssh #{@user}@#{@host} #{@sshport} [ -f "#{file}" ] && echo 1 || echo 0`[0] == "1"
           puts file + " exists"
           return true
         else


### PR DESCRIPTION
Hi,

For me the file exists did not seem to work properly as it was misclassifying all files as being non-existent, resulting in some unnecessary updating.

It seemed the original check, i.e. checking if the string equals "1" did always returned false. This PR replaces it with a check on just the first character.

The exact cause is unknown for me, but I assume some trailing characters exist by using chomp on a plain "1". Maybe some dependency has changed behavior. It's a bit unclear to me but in general I think this is more stable.

Ruby version:
`ruby 2.6.6p146 (2020-03-31 revision 67876) [x64-mingw32]`